### PR TITLE
Fix argparse bug

### DIFF
--- a/autoprocprio.py
+++ b/autoprocprio.py
@@ -64,7 +64,7 @@ if platform_is_windows():
     import win32api  # For catching user closing the app window via the X icon
 
 SCRIPT_NAME = "AutoProcPrio"
-SCRIPT_VERSION = "6.1.0"
+SCRIPT_VERSION = "6.1.1"
 
 
 def add_app(executable_name):
@@ -409,7 +409,7 @@ def main():
         for procname in [
             x
             for x in list(set(args.good.split(",")))
-            if add_app(x) not in GOOD_PROCNAMES
+            if add_app(x) not in [y.procname for y in PROCS]
         ]:
             PROCS.append(
                 TargetProcs(
@@ -428,7 +428,7 @@ def main():
         for procname in [
             x
             for x in list(set(args.bad.split(",")))
-            if add_app(x) not in BAD_PROCNAMES
+            if add_app(x) not in [y.procname for y in PROCS]
         ]:
             PROCS.append(
                 TargetProcs(add_app(procname), BAD_NICENESS, BAD_AFFINITY,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "autoprocprio"
-version = "6.1.0"
+version = "6.1.1"
 description = "Automatically prioritize important apps' CPU priority and affinity"
 authors = ["Rain <Rainyan@users.noreply.github.com>"]
 license = "MIT License"

--- a/version.rc
+++ b/version.rc
@@ -1,7 +1,7 @@
 VSVersionInfo(
   ffi=FixedFileInfo(
-    filevers=(6, 1, 0, 0),
-    prodvers=(6, 1, 0, 0),
+    filevers=(6, 1, 1, 0),
+    prodvers=(6, 1, 1, 0),
     mask=0x3f,
     flags=0x0,
     OS=0x40004,
@@ -15,12 +15,12 @@ VSVersionInfo(
       StringTable(
         u'040904B0',
         [StringStruct(u'FileDescription', u'Automatically prioritize important apps\x27 CPU priority and affinity'),
-        StringStruct(u'FileVersion', u'6.1.0'),
+        StringStruct(u'FileVersion', u'6.1.1'),
         StringStruct(u'InternalName', u'autoprocprio'),
         StringStruct(u'LegalCopyright', u'\xa9 github.com/Rainyan. MIT licensed.'),
         StringStruct(u'OriginalFilename', u'autoprocprio.exe'),
         StringStruct(u'ProductName', u'AutoProcPrio'),
-        StringStruct(u'ProductVersion', u'6.1.0')])
+        StringStruct(u'ProductVersion', u'6.1.1')])
       ]),
     VarFileInfo([VarStruct(u'Translation', [1033, 1200])])
   ]


### PR DESCRIPTION
Fix a bug where explicitly specifying procs with the -g/-b parameters would fail because we incorrectly assumed that proc was already applied, not taking into count that we wanted to overwrite it in the first place.