### PR TITLE
Optimize CPU affinity

### DIFF
--- a/autoprocprio.py
+++ b/autoprocprio.py
@@ -45,7 +45,7 @@ if platform_is_windows():
     import win32api  # For catching user closing the app window via the X icon
 
 SCRIPT_NAME = "AutoProcPrio"
-SCRIPT_VERSION = "9.0.2"
+SCRIPT_VERSION = "10.0.0"
 
 
 def add_app(executable_name):
@@ -86,17 +86,27 @@ EXITING = False
 
 # For Windows, this is the "low priority" option on taskmgr.
 BAD_NICENESS = psutil.IDLE_PRIORITY_CLASS if platform_is_windows() else 15
-# Force buggy procs on these core(s).
-BAD_AFFINITY = [0, ]
+# How many cores to dedicate for buggy/badly behaving apps.
+NUM_BAD_AFFINITY_CORES = 1
 # If you don't want to set this, pass None to the TargetProcs ctor arg.
-assert len(BAD_AFFINITY) > 0, "Need at least one CPU core"
+assert NUM_BAD_AFFINITY_CORES > 0, "Need at least one CPU core"
 
 # For Windows, this is the "high priority" option on taskmgr.
 GOOD_NICENESS = psutil.HIGH_PRIORITY_CLASS if platform_is_windows() else -15
-# Use all cores except the one(s) reserved for "bad" procs.
-GOOD_AFFINITY = [a for a in list(range(cpu_count())) if a not in BAD_AFFINITY]
+
+GOOD_AFFINITY = [a for a in list(range(cpu_count()))]
+# We are reserving cores starting from the end, because for modern CPUs with
+# performance/economy cores (Intel) or 3D V-Cache (AMD), the cores with worse
+# performance in games tend to be allocated to the latter half.
+# We should ideally enumerate and identify the cores properly for both Windows & Linux,
+# but this should be good enough for the current CPU gens out there, as of April 2025.
+# See associated bug for more context: https://github.com/Rainyan/autoprocprio/issues/27
+BAD_AFFINITY = GOOD_AFFINITY[-NUM_BAD_AFFINITY_CORES:]
+# Exclude the "bad cores" from the good ones.
+GOOD_AFFINITY = GOOD_AFFINITY[:-NUM_BAD_AFFINITY_CORES]
 # If you don't want to set this, pass None to the TargetProcs ctor arg.
 assert len(GOOD_AFFINITY) > 0, "Need at least one CPU core"
+assert len(BAD_AFFINITY) > 0, "Need at least one CPU core"
 
 
 def is_admin():

--- a/autoprocprio.py
+++ b/autoprocprio.py
@@ -98,9 +98,11 @@ GOOD_AFFINITY = [a for a in list(range(cpu_count()))]
 # We are reserving cores starting from the end, because for modern CPUs with
 # performance/economy cores (Intel) or 3D V-Cache (AMD), the cores with worse
 # performance in games tend to be allocated to the latter half.
-# We should ideally enumerate and identify the cores properly for both Windows & Linux,
-# but this should be good enough for the current CPU gens out there, as of April 2025.
-# See associated bug for more context: https://github.com/Rainyan/autoprocprio/issues/27
+# We should ideally enumerate and identify the cores properly for both
+# Windows & Linux, but this should be good enough for the current CPU gens
+# out there, as of April 2025.
+# See associated bug for more context:
+# https://github.com/Rainyan/autoprocprio/issues/27
 BAD_AFFINITY = GOOD_AFFINITY[-NUM_BAD_AFFINITY_CORES:]
 # Exclude the "bad cores" from the good ones.
 GOOD_AFFINITY = GOOD_AFFINITY[:-NUM_BAD_AFFINITY_CORES]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "autoprocprio"
-version = "9.0.2"
+version = "10.0.0"
 description = "Automatically prioritize important apps' CPU priority and affinity"
 authors = ["Rain <Rainyan@users.noreply.github.com>"]
 license = "MIT License"

--- a/version.rc
+++ b/version.rc
@@ -1,7 +1,7 @@
 VSVersionInfo(
   ffi=FixedFileInfo(
-    filevers=(9, 0, 2, 0),
-    prodvers=(9, 0, 2, 0),
+    filevers=(10, 0, 0, 0),
+    prodvers=(10, 0, 0, 0),
     mask=0x3f,
     flags=0x0,
     OS=0x40004,
@@ -15,12 +15,12 @@ VSVersionInfo(
       StringTable(
         u'040904B0',
         [StringStruct(u'FileDescription', u'Automatically prioritize important apps\x27 CPU priority and affinity'),
-        StringStruct(u'FileVersion', u'9.0.2'),
+        StringStruct(u'FileVersion', u'10.0.0'),
         StringStruct(u'InternalName', u'autoprocprio'),
         StringStruct(u'LegalCopyright', u'\xa9 github.com/Rainyan. MIT licensed.'),
         StringStruct(u'OriginalFilename', u'autoprocprio.exe'),
         StringStruct(u'ProductName', u'AutoProcPrio'),
-        StringStruct(u'ProductVersion', u'9.0.2')])
+        StringStruct(u'ProductVersion', u'10.0.0')])
       ]),
     VarFileInfo([VarStruct(u'Translation', [1033, 1200])])
   ]


### PR DESCRIPTION
Optimize affinity behaviour for modern CPUs to prefer the "economy" cores for non-gaming workloads.

This is just a hack to improve the default behaviour, so I'm not closing the issue.

For more details, see the related issue: https://github.com/Rainyan/autoprocprio/issues/27